### PR TITLE
Use TLS for all endpoints

### DIFF
--- a/serverside-checklist.md
+++ b/serverside-checklist.md
@@ -83,7 +83,7 @@ This is a checklist for serverside of the Web App.
 ## Security
 
 * [ ] I have audited my system against OWASP Top 10 Vulnerabilities
-* [ ] I use TLS for all sensitive endpoints
+* [ ] I use TLS for all endpoints
 * [ ] I have added relevant security headers to app HTTP endpoints
 
   * `X-Frame-Options`


### PR DESCRIPTION
Hello,

I think the up-to-the-moment push from web browsers to accept that new applications should deliver content entirely via HTTPS. Not just login to the site, but everything (pictures, scripts, posts, comments).

Greetings,